### PR TITLE
Add pyproject.toml to enable pip installation and pyilc cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info
+*/__pycache__/*

--- a/pyilc/main.py
+++ b/pyilc/main.py
@@ -3,69 +3,72 @@ import sys
 import numpy as np
 import os
 import healpy as hp
-from input import ILCInfo
-from wavelets import Wavelets, wavelet_ILC, harmonic_ILC
+from .input import ILCInfo
+from .wavelets import Wavelets, wavelet_ILC, harmonic_ILC
 """
 main script for doing needlet or harmonic (multiply constrained) ILC analysis
 """
-##########################
-# main input file
-### input file containing most specifications ###
-try:
-    input_file = (sys.argv)[1]
-except IndexError:
-    input_file = '../input/pyilc_input_example_general.yml'
-##########################
+def main():
+    ##########################
+    # main input file
+    ### input file containing most specifications ###
+    try:
+        input_file = (sys.argv)[1]
+    except IndexError:
+        input_file = '../input/pyilc_input_example_general.yml'
+    ##########################
 
-##########################
-# read in the input file and set up relevant info object
-info = ILCInfo(input_file)
-##########################
-# read in frequency maps (Update: this is now done in wavelets.py only if the maps needlet coeffs have not already been computed and saved.
-# otherwise we don't need to read in the maps at all.
-#info.read_maps() 
-##########################
-# read in bandpasses
-info.read_bandpasses()
-# read in beams
-info.read_beams()
-# read in geometries
-if info.work_in_car:
-    info.read_geometries()
-##########################
+    ##########################
+    # read in the input file and set up relevant info object
+    info = ILCInfo(input_file)
+    ##########################
+    # read in frequency maps (Update: this is now done in wavelets.py only if the maps needlet coeffs have not already been computed and saved.
+    # otherwise we don't need to read in the maps at all.
+    #info.read_maps() 
+    ##########################
+    # read in bandpasses
+    info.read_bandpasses()
+    # read in beams
+    info.read_beams()
+    # read in geometries
+    if info.work_in_car:
+        info.read_geometries()
+    ##########################
 
-##########################
-# construct wavelets
-wv = Wavelets(N_scales=info.N_scales, ELLMAX=info.ELLMAX, tol=1.e-6, taper_width=info.taper_width)
-if info.wavelet_type == 'GaussianNeedlets':
-    ell, filts = wv.GaussianNeedlets(FWHM_arcmin=info.GN_FWHM_arcmin)
-elif info.wavelet_type == 'CosineNeedlets': # Fiona added CosineNeedlets
-    ell,filts = wv.CosineNeedlets(ellmin = info.ellmin,ellpeaks = info.ellpeaks)
-elif info.wavelet_type == 'TopHatHarmonic':
-    ell,filts = wv.TopHatHarmonic(info.ellbins)
-elif info.wavelet_type == 'TaperedTopHats':
-    ell,filts = wv.TaperedTopHats(ellboundaries = info.ellboundaries,taperwidths=info.taperwidths)
-else:
-    raise TypeError('unsupported wavelet type')
-# example plot -- output in example_wavelet_plot
-#wv.plot_wavelets(log_or_lin='lin')
-##########################
+    ##########################
+    # construct wavelets
+    wv = Wavelets(N_scales=info.N_scales, ELLMAX=info.ELLMAX, tol=1.e-6, taper_width=info.taper_width)
+    if info.wavelet_type == 'GaussianNeedlets':
+        ell, filts = wv.GaussianNeedlets(FWHM_arcmin=info.GN_FWHM_arcmin)
+    elif info.wavelet_type == 'CosineNeedlets': # Fiona added CosineNeedlets
+        ell,filts = wv.CosineNeedlets(ellmin = info.ellmin,ellpeaks = info.ellpeaks)
+    elif info.wavelet_type == 'TopHatHarmonic':
+        ell,filts = wv.TopHatHarmonic(info.ellbins)
+    elif info.wavelet_type == 'TaperedTopHats':
+        ell,filts = wv.TaperedTopHats(ellboundaries = info.ellboundaries,taperwidths=info.taperwidths)
+    else:
+        raise TypeError('unsupported wavelet type')
+    # example plot -- output in example_wavelet_plot
+    #wv.plot_wavelets(log_or_lin='lin')
+    ##########################
 
-##########################
-# wavelet ILC
-if info.wavelet_type == 'TopHatHarmonic':
-    info.read_maps()
-    if not info.weights_exist:
-        info.maps2alms()
-        info.alms2cls()
-    if info.maps_to_apply_weights:
-        info.maps_to_apply_weights2alms()
-    harmonic_ILC(wv, info, resp_tol=info.resp_tol, map_images=False)
-else:
-    wavelet_ILC(wv, info, resp_tol=info.resp_tol, map_images=False)
-##########################
+    ##########################
+    # wavelet ILC
+    if info.wavelet_type == 'TopHatHarmonic':
+        info.read_maps()
+        if not info.weights_exist:
+            info.maps2alms()
+            info.alms2cls()
+        if info.maps_to_apply_weights:
+            info.maps_to_apply_weights2alms()
+        harmonic_ILC(wv, info, resp_tol=info.resp_tol, map_images=False)
+    else:
+        wavelet_ILC(wv, info, resp_tol=info.resp_tol, map_images=False)
+    ##########################
 
-##########################
-# TODO
-# add simple code to cross-correlate the output ILC map with input map specified by the user (useful for simulations/validation)
-##########################
+    ##########################
+    # TODO
+    # add simple code to cross-correlate the output ILC map with input map specified by the user (useful for simulations/validation)
+    ##########################
+if __name__ == "__main__":
+    main()

--- a/pyilc/wavelets.py
+++ b/pyilc/wavelets.py
@@ -74,8 +74,8 @@ matplotlib.rc('text', usetex=True)
 fontProperties = {'family':'sans-serif',
                   'weight' : 'normal', 'size' : 16}
 import matplotlib.pyplot as plt
-from input import ILCInfo
-from fg import get_mix, get_mix_bandpassed
+from .input import ILCInfo
+from .fg import get_mix, get_mix_bandpassed
 import time
 """
 this module constructs the Wavelets class, which contains the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=64.0.0"]
+
+[tool.setuptools.packages.find]
+exclude=["*data*", "*input*", "*notebooks*", "*plots*"]
+
+[project]
+name="pyilc"
+requires-python = ">=3.10"
+version = "0.0.1"
+dependencies = [
+    "numpy",
+    "matplotlib",
+    "healpy",
+    "pixell"
+]
+readme = "README.md"
+license = {file = "LICENSE"}
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Astronomy",
+    "Topic :: Scientific/Engineering :: Physics",
+]
+description="Needlet ILC in Python"
+
+[project.scripts]
+pyilc = "pyilc.main:main"
+
+[project.urls]
+Homepage = "https://github.com/jcolinhill/pyilc"


### PR DESCRIPTION
This adds a basic pyproject.toml that can be improved in the future.

You should now be able to `pip install -e .` in your `pyilc` directory and install the package.

I've added a command-line wrapper, `pyilc` that will be installed on your system when you install the package. As such, if you want to use `pyilc/main.py`, you can type:
```
pyilc my_config.yml
```
Instead of:
```
python3 pyilc/main.py my_config.yml
```
This is a necessary step to ensure that pyilc's features can be used in other packages when needed.

If you have a chance to test and potentially merge this, I'd appreciate it.
